### PR TITLE
solution

### DIFF
--- a/.github/workflows/helm-deploy.yml
+++ b/.github/workflows/helm-deploy.yml
@@ -1,0 +1,88 @@
+name: helm-deploy
+run-name: ${{ github.actor }} - ${{ github.ref_name }}
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        description: 'Environment to deploy to'
+        type: string
+      version:
+        required: true
+        description: 'Version of the image to deploy'
+        type: string
+      helm-values-path:
+        description: 'Path to the helm values file'
+        type: string
+        default: './todoapp/values.yaml'
+      helm-release-name:
+        description: 'helm upgrade name'
+        type: string
+        default: 'todoapp'
+
+jobs:
+  helm-cd:
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    name: deploy todoapp to kind cluster via Helm
+    steps:
+    - name: download cluster config
+      uses: actions/download-artifact@v4
+      with:
+        name: cluster-artifact      # downloading "cluster.yml" file in root
+
+    - name: Create k8s Kind Cluster
+      uses: helm/kind-action@v1
+      with:
+        config: ./cluster.yml
+
+    - name: download helm charts
+      uses: actions/download-artifact@v4
+      with:
+        name: helm-charts
+        path: .                     # downloading "todoapp/" directory in root
+
+    - name: download helm package
+      uses: actions/download-artifact@v4
+      with:
+        name: helm-package
+        path: .                     # downloading "*ChartName-*version.tgz" in root
+
+    - name: Set Up Helm
+      uses: azure/setup-helm@v4.2.0
+
+    - name: Set Up kubectl
+      uses: azure/setup-kubectl@v4
+      id: install
+
+    - name: Helm dry-run
+      run: |
+        helm install --dry-run ${{ inputs.helm-release-name }} ./todoapp-*.tgz \
+        -f ${{ inputs.helm-values-path }} \
+        --set mysql.secrets.MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }} \
+        --set mysql.secrets.MYSQL_USER=${{ secrets.MYSQL_USER }} \
+        --set mysql.secrets.MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }} \
+        --set todoapp.secrets.SECRET_KEY=${{ secrets.SECRET_KEY }} \
+        --set todoapp.secrets.DB_NAME=${{ secrets.DB_NAME }} \
+        --set todoapp.secrets.DB_USER=${{ secrets.DB_USER }} \
+        --set todoapp.secrets.DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+        --set todoapp.secrets.DB_HOST=${{ secrets.DB_HOST }} \
+        --set todoapp.image.repository=${{ secrets.DOCKERHUB_USERNAME }}/todoapp \
+        --set todoapp.image.tag="${{ inputs.version }}"
+
+    - name: helm chart deploying
+      run: |
+        helm upgrade --install --atomic --debug --wait --timeout 3m0s \
+        ${{ inputs.helm-release-name }} ./todoapp-*.tgz \
+        -f ${{ inputs.helm-values-path }} \
+        --set mysql.secrets.MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }} \
+        --set mysql.secrets.MYSQL_USER=${{ secrets.MYSQL_USER }} \
+        --set mysql.secrets.MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }} \
+        --set todoapp.secrets.SECRET_KEY=${{ secrets.SECRET_KEY }} \
+        --set todoapp.secrets.DB_NAME=${{ secrets.DB_NAME }} \
+        --set todoapp.secrets.DB_USER=${{ secrets.DB_USER }} \
+        --set todoapp.secrets.DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+        --set todoapp.secrets.DB_HOST=${{ secrets.DB_HOST }} \
+        --set todoapp.image.repository=${{ secrets.DOCKERHUB_USERNAME }}/todoapp \
+        --set todoapp.image.tag="${{ inputs.version }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,3 +124,69 @@ jobs:
       with:
         name: helm-package
         path: ./*.tgz               # uploading "*ChartName-*version.tgz"
+
+  helm-cd:
+    needs: [ docker-ci, helm-ci ]
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    name: deploy todoapp to kind cluster via Helm
+    steps:
+    - name: download cluster config
+      uses: actions/download-artifact@v4
+      with:
+        name: cluster-artifact      # downloading "cluster.yml" file in root
+
+    - name: Create k8s Kind Cluster
+      uses: helm/kind-action@v1
+      with:
+        config: ./cluster.yml
+
+    - name: download helm charts
+      uses: actions/download-artifact@v4
+      with:
+        name: helm-charts
+        path: .                     # downloading "todoapp/" directory in root
+
+    - name: download helm package
+      uses: actions/download-artifact@v4
+      with:
+        name: helm-package
+        path: .                     # downloading "*ChartName-*version.tgz" in root
+
+    - name: Set Up Helm
+      uses: azure/setup-helm@v4.2.0
+
+    - name: Set Up kubectl
+      uses: azure/setup-kubectl@v4
+      id: install
+
+    - name: Helm dry-run
+      run: |
+        helm install --dry-run todoapp ./todoapp-*.tgz \
+        -f ./todoapp/values.yaml \
+        --set mysql.secrets.MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }} \
+        --set mysql.secrets.MYSQL_USER=${{ secrets.MYSQL_USER }} \
+        --set mysql.secrets.MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }} \
+        --set todoapp.secrets.SECRET_KEY=${{ secrets.SECRET_KEY }} \
+        --set todoapp.secrets.DB_NAME=${{ secrets.DB_NAME }} \
+        --set todoapp.secrets.DB_USER=${{ secrets.DB_USER }} \
+        --set todoapp.secrets.DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+        --set todoapp.secrets.DB_HOST=${{ secrets.DB_HOST }} \
+        --set todoapp.image.repository=${{ secrets.DOCKERHUB_USERNAME }}/todoapp \
+        --set todoapp.image.tag="${{ github.sha }}"
+
+    - name: helm chart deploying
+      run: |
+        helm upgrade --install --atomic --debug --wait --timeout 3m0s \
+        todoapp ./todoapp-*.tgz \
+        -f ./todoapp/values.yaml \
+        --set mysql.secrets.MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }} \
+        --set mysql.secrets.MYSQL_USER=${{ secrets.MYSQL_USER }} \
+        --set mysql.secrets.MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }} \
+        --set todoapp.secrets.SECRET_KEY=${{ secrets.SECRET_KEY }} \
+        --set todoapp.secrets.DB_NAME=${{ secrets.DB_NAME }} \
+        --set todoapp.secrets.DB_USER=${{ secrets.DB_USER }} \
+        --set todoapp.secrets.DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+        --set todoapp.secrets.DB_HOST=${{ secrets.DB_HOST }} \
+        --set todoapp.image.repository=${{ secrets.DOCKERHUB_USERNAME }}/todoapp \
+        --set todoapp.image.tag="${{ github.sha }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,18 +50,24 @@ jobs:
         run: |
           flake8 . --exit-zero --max-complexity=6
 
-      - name: Upload python artifacts
+      - name: Upload python App files
         uses: actions/upload-artifact@v4
         with:
-          name: python-artifacts
-          path: .
+          name: python-app-files
+          path: ./src                 # uploading files from "src" directory
 
-      - name: Upload helm artifacts
+      - name: Upload helm charts
         if: github.ref_name == 'main'
         uses: actions/upload-artifact@v4
         with:
-          name: helm-artifacts
-          path: ${{ github.workspace }}/helm-charts
+          name: helm-charts
+          path: ./helm-charts         # uploading "todoapp/" directory
+
+      - name: Upload cluster configs
+        uses: actions/upload-artifact@v4
+        with:
+          name: cluster-artifact
+          path: ./cluster.yml         # uploading "cluster.yml" file
 
   docker-ci:
     name: Build and Push Image
@@ -70,11 +76,11 @@ jobs:
     needs: python-ci
     steps:
 
-    - uses: actions/download-artifact@v4
-      name: Download python artifacts
+    - name: Download App files
+      uses: actions/download-artifact@v4
       with:
-        name: python-artifacts
-        path: .
+        name: python-app-files
+        path: ./src                   # downloading files from "src" directory
 
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -95,26 +101,26 @@ jobs:
     if: github.ref_name == 'main'
     name: Helm CI
     steps:
-
-    - uses: actions/download-artifact@v4
+    - name: download helm charts
+      uses: actions/download-artifact@v4
       with:
-        name: helm-artifacts
-        path: .
+        name: helm-charts
+        path: .                     # downloading "todoapp/" directory in root
 
     - name: Set Up Helm
       uses: azure/setup-helm@v4.2.0
 
     - name: Lint helm
-      run: helm lint ./todoapp/
+      run: helm lint ./todoapp
 
     - name: Template Helm
       run: helm template todoapp ./todoapp/ -f ./todoapp/values.yaml
 
     - name: Package Helm
-      run: helm package ./todoapp
+      run: helm package ./todoapp   # packing files from "todoapp" directory in archive "*ChartName-*version.tgz"
 
-    - name: Upload Helm Artifact
+    - name: Upload Helm Package
       uses: actions/upload-artifact@v4
       with:
         name: helm-package
-        path: ./*.tgz
+        path: ./*.tgz               # uploading "*ChartName-*version.tgz"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,68 +125,23 @@ jobs:
         name: helm-package
         path: ./*.tgz               # uploading "*ChartName-*version.tgz"
 
-  helm-cd:
-    needs: [ docker-ci, helm-ci ]
-    if: github.ref_name == 'main'
-    runs-on: ubuntu-latest
-    name: deploy todoapp to kind cluster via Helm
-    steps:
-    - name: download cluster config
-      uses: actions/download-artifact@v4
-      with:
-        name: cluster-artifact      # downloading "cluster.yml" file in root
+  helm-cd-dev:
+    name: Helm deployment dev
+    uses: ./.github/workflows/helm-deploy.yml
+    needs: [ "helm-ci", "docker-ci"]
+    secrets: inherit
+    with:
+      environment: development
+      version: ${{ github.sha }}
+      helm-release-name: todoapp-dev
 
-    - name: Create k8s Kind Cluster
-      uses: helm/kind-action@v1
-      with:
-        config: ./cluster.yml
-
-    - name: download helm charts
-      uses: actions/download-artifact@v4
-      with:
-        name: helm-charts
-        path: .                     # downloading "todoapp/" directory in root
-
-    - name: download helm package
-      uses: actions/download-artifact@v4
-      with:
-        name: helm-package
-        path: .                     # downloading "*ChartName-*version.tgz" in root
-
-    - name: Set Up Helm
-      uses: azure/setup-helm@v4.2.0
-
-    - name: Set Up kubectl
-      uses: azure/setup-kubectl@v4
-      id: install
-
-    - name: Helm dry-run
-      run: |
-        helm install --dry-run todoapp ./todoapp-*.tgz \
-        -f ./todoapp/values.yaml \
-        --set mysql.secrets.MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }} \
-        --set mysql.secrets.MYSQL_USER=${{ secrets.MYSQL_USER }} \
-        --set mysql.secrets.MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }} \
-        --set todoapp.secrets.SECRET_KEY=${{ secrets.SECRET_KEY }} \
-        --set todoapp.secrets.DB_NAME=${{ secrets.DB_NAME }} \
-        --set todoapp.secrets.DB_USER=${{ secrets.DB_USER }} \
-        --set todoapp.secrets.DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
-        --set todoapp.secrets.DB_HOST=${{ secrets.DB_HOST }} \
-        --set todoapp.image.repository=${{ secrets.DOCKERHUB_USERNAME }}/todoapp \
-        --set todoapp.image.tag="${{ github.sha }}"
-
-    - name: helm chart deploying
-      run: |
-        helm upgrade --install --atomic --debug --wait --timeout 3m0s \
-        todoapp ./todoapp-*.tgz \
-        -f ./todoapp/values.yaml \
-        --set mysql.secrets.MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }} \
-        --set mysql.secrets.MYSQL_USER=${{ secrets.MYSQL_USER }} \
-        --set mysql.secrets.MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }} \
-        --set todoapp.secrets.SECRET_KEY=${{ secrets.SECRET_KEY }} \
-        --set todoapp.secrets.DB_NAME=${{ secrets.DB_NAME }} \
-        --set todoapp.secrets.DB_USER=${{ secrets.DB_USER }} \
-        --set todoapp.secrets.DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
-        --set todoapp.secrets.DB_HOST=${{ secrets.DB_HOST }} \
-        --set todoapp.image.repository=${{ secrets.DOCKERHUB_USERNAME }}/todoapp \
-        --set todoapp.image.tag="${{ github.sha }}"
+  helm-cd-stg:
+    name: Helm deployment stg
+    uses: ./.github/workflows/helm-deploy.yml
+    needs: [ "helm-ci", "docker-ci"]
+    secrets: inherit
+    with:
+      environment: staging
+      version: ${{ github.sha }}
+      helm-release-name: todoapp-stg
+      helm-values-path: ./todoapp/values/stg.yaml

--- a/helm-charts/todoapp/values.yaml
+++ b/helm-charts/todoapp/values.yaml
@@ -1,14 +1,14 @@
 mysql:
   secrets:
-    MYSQL_ROOT_PASSWORD: 12345
-    MYSQL_USER: app_user
-    MYSQL_PASSWORD: 1234
+    MYSQL_ROOT_PASSWORD: placeholder
+    MYSQL_USER: placeholder
+    MYSQL_PASSWORD: placeholder
 
 todoapp:
   namespace: todoapp
   image:
-    repository: ikulyk404/todoapp
-    tag: "4.0.1"
+    repository: placeholder
+    tag: placeholder
 
   resources:
     requests:
@@ -19,11 +19,11 @@ todoapp:
       cpu: "150m"
 
   secrets:
-    SECRET_KEY: zdfsadfsadfsfs
-    DB_NAME: app_db
-    DB_USER: app_user
-    DB_PASSWORD: 1234
-    DB_HOST: mysql-0.mysql.mysql.svc.cluster.local
+    SECRET_KEY: placeholder
+    DB_NAME: placeholder
+    DB_USER: placeholder
+    DB_PASSWORD: placeholder
+    DB_HOST: placeholder
 
   hpa:
     minReplicas: 2

--- a/helm-charts/todoapp/values/stg.yaml
+++ b/helm-charts/todoapp/values/stg.yaml
@@ -1,7 +1,7 @@
 todoapp:
   namespace: todoapp
   image:
-    repository: ikulyk404/todoapp
+    repository: yegorv/todoapp
 
   resources:
     requests:


### PR DESCRIPTION
reference to a successful workflow run.
https://github.com/YegorVolkov/devops_todolist_cicd_task_5_deploy_to_k8s/actions/runs/10181031261

I have got a quastion:
we were tought to use 
```
    - name: Upload Helm Package
      uses: actions/upload-artifact@v4
      with:
        name: helm-package
        path: ./*.tgz           
```
which basically archives the files in the chart directory and names archive with the ${chart-name}-${chart-version}
meanwhile when we need to use this archive in the following job we download this archive
BUT if we need to use custom values file:
we need ALSO to download raw charts directory to have access to values files which we adress in the 
`helm install --dry-run todoapp ./todoapp-*.tgz -f ./todoapp/values.yaml`
`helm install --dry-run todoapp ./todoapp-*.tgz -f ./todoapp/values/stg.yaml`
which is in other words - downloading same files twice.
I assume all this was done in learning scope Only: in real projects we download once, and the way we use depends on either we need or not the custom value file?
OR is it a good practice to use helm packaging for some other reasons?